### PR TITLE
Output DA junctions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ include(TestHelper)
 
 #versioning stuff
 set (regtools_VERSION_MAJOR 0)
-set (regtools_VERSION_MINOR 3)
+set (regtools_VERSION_MINOR 4)
 set (regtools_VERSION_PATCH 0)
 configure_file (
     "${PROJECT_SOURCE_DIR}/src/version.h.in"

--- a/src/cis-splice-effects/cis_splice_effects_identifier.cc
+++ b/src/cis-splice-effects/cis_splice_effects_identifier.cc
@@ -158,14 +158,12 @@ void CisSpliceEffectsIdentifier::annotate_junctions(const GtfParser& gp1) {
         AnnotatedJunction line(j);
         ja1.get_splice_site(line);
         ja1.annotate_junction_with_gtf(line);
-        if(line.anchor != "DA") {
-            if(output_junctions_bed_ != "NA") {
-                j.name = get_junction_name(++i);
-                j.print(ofs_junctions_bed_);
-            }
-            line.variant_info = variant_set_to_string(junction_to_variant_[j]);
-            line.print(ofs_, true);
+        if(output_junctions_bed_ != "NA") {
+            j.name = get_junction_name(++i);
+            j.print(ofs_junctions_bed_);
         }
+        line.variant_info = variant_set_to_string(junction_to_variant_[j]);
+        line.print(ofs_, true);
     }
     close_ostream();
 }


### PR DESCRIPTION
- Currently cis-splice effects only outputs the 'abnormal' i.e non DA junctions, modify this to also output the DA junctions. The idea behind this is that the users can filter these results downstream with some straightforward scripting to select the types of junctions they are interested in.
- This is a pretty big change, bump up the version to 0.4