### PR TITLE
add option to specify strand tag in bam for junction_extractor

### DIFF
--- a/src/junctions/junctions_extractor.cc
+++ b/src/junctions/junctions_extractor.cc
@@ -229,7 +229,7 @@ void JunctionsExtractor::print_all_junctions(ostream& out) {
 
 //Get the strand from the XS aux tag
 void JunctionsExtractor::set_junction_strand_XS(bam1_t *aln, Junction& j1) {
-    uint8_t *p = bam_aux_get(aln, "XS");
+    uint8_t *p = bam_aux_get(aln, strand_tag_.c_str());
     if(p != NULL) {
         char strand = bam_aux2A(p);
         strand ? j1.strand = string(1, strand) : j1.strand = string(1, '?');

--- a/src/junctions/junctions_extractor.cc
+++ b/src/junctions/junctions_extractor.cc
@@ -41,7 +41,7 @@ int JunctionsExtractor::parse_options(int argc, char *argv[]) {
     optind = 1; //Reset before parsing again.
     int c;
     stringstream help_ss;
-    while((c = getopt(argc, argv, "ha:m:M:o:r:s:")) != -1) {
+    while((c = getopt(argc, argv, "ha:m:M:o:r:t:s:")) != -1) {
         switch(c) {
             case 'a':
                 min_anchor_length_ = atoi(optarg);
@@ -57,6 +57,9 @@ int JunctionsExtractor::parse_options(int argc, char *argv[]) {
                 break;
             case 'r':
                 region_ = string(optarg);
+                break;
+            case 't':
+                strand_tag_ = string(optarg);
                 break;
             case 'h':
                 usage(help_ss);
@@ -104,6 +107,8 @@ int JunctionsExtractor::usage(ostream& out) {
         << "\t\t\t " << "in \"chr:start-end\" format. Entire BAM by default." << endl;
     out << "\t\t" << "-s INT\tStrand specificity of RNA library preparation \n"
         << "\t\t\t " << "(0 = unstranded, 1 = first-strand/RF, 2, = second-strand/FR). REQUIRED" << endl;
+    out << "\t\t" << "-t STR\tTag used in bam to label strand. [XS]" << endl;
+        
     out << endl;
     return 0;
 }

--- a/src/junctions/junctions_extractor.h
+++ b/src/junctions/junctions_extractor.h
@@ -155,6 +155,8 @@ class JunctionsExtractor {
         string region_;
         //strandness of data; 0 = unstranded, 1 = RF, 2 = FR
         int strandness_;
+        //tag used in BAM to denote strand, default "XS"
+        string strand_tag_;
     public:
         //Default constructor
         JunctionsExtractor() {
@@ -163,6 +165,7 @@ class JunctionsExtractor {
             max_intron_length_ = 500000;
             junctions_sorted_ = false;
             strandness_ = -1;
+            strand_tag_ = "XS";
             bam_ = "NA";
             output_file_ = "NA";
             region_ = ".";


### PR DESCRIPTION
Some aligners (e.g. minimap2) use tags other than XS to represent strand. This adds an option to change from the default to e.g. ts ala minimap2. 